### PR TITLE
Fix: fixed the command error for Edit .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Before you begin, ensure you have met the following requirements:
 4. **Edit .env:**
 
    ```
-   cp .env.example > .env
+   cp .env.example .env
    ```
 
 5. **Init Prisma:**


### PR DESCRIPTION
I've corrected the error in the 
#### 4. Edit .env in the README file

from 
```
cp .env.example > .env
```
to
```
cp .env.example .env
```
Which what it basically does is to copy the contents of `.env.example` file to `.env` file and it's now working as expected