### PR TITLE
Added trend link in the navbar

### DIFF
--- a/components/core/Sidebar.tsx
+++ b/components/core/Sidebar.tsx
@@ -33,9 +33,9 @@ const Sidebar = ({ children }: { children: React.ReactNode }) => {
       },
       {
         icon: BiTrendingUp,
-        label: "Trend",
-        href: "/trend",
-        active: pathname === "/trend",
+        label: "Trends",
+        href: "/trends",
+        active: pathname === "/trends",
       },
       {
         icon: AiOutlineSearch,

--- a/components/core/Sidebar.tsx
+++ b/components/core/Sidebar.tsx
@@ -2,6 +2,7 @@
 
 import React, { useMemo } from "react";
 import { AiOutlineHome, AiOutlineSearch, AiOutlinePlus } from "react-icons/ai";
+import { BiTrendingUp } from "react-icons/bi";
 import { Button } from "@/components/ui/button";
 
 import { usePathname } from "next/navigation";
@@ -29,6 +30,12 @@ const Sidebar = ({ children }: { children: React.ReactNode }) => {
         label: "Home",
         active: pathname === "/",
         href: "/",
+      },
+      {
+        icon: BiTrendingUp,
+        label: "Trend",
+        href: "/trend",
+        active: pathname === "/trend",
       },
       {
         icon: AiOutlineSearch,


### PR DESCRIPTION
I've added Trend link and it's now getting displayed on both the Desktop navbar or Mobile bottom navbar, below are the screenshots of how it's now:
![trend-after](https://github.com/p7uverma/SnapLine/assets/67334984/16b3aadf-31b3-4bc1-bf99-f56b49b75676)
![trend-after-desktop](https://github.com/p7uverma/SnapLine/assets/67334984/dc5a9f87-c3e5-468f-9821-d4693089785a)
